### PR TITLE
remove static (non-threadsafe) mocking of claims; add per-request claims control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider/et al working folder
+.idea

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or via the .NET Core command line interface:
 
     dotnet add package FakeAuth
 
-Either commands, from Package Manager Console or .NET Core CLI, will download and install FakeAuth and all required dependencies.
+Either command, from Package Manager Console or .NET Core CLI, will download and install FakeAuth and all required dependencies.
 
 ### Using FakeAuth
 
@@ -38,9 +38,8 @@ That will give you a default profile. In fact, the above is exactly the same as 
 
     services.UseFakeAuth<DefaultProfile>();
 
-You can created custom profiles by implementing the interface [IFakeAuthProfile](https://github.com/calebjenkins/FakeAuth/blob/main/src/FakeAuth/Profiles/IFakeAuthProfile.cs)
-
-Or you can inline your custom claims directly:
+You can create custom profiles by implementing the interface [IFakeAuthProfile](https://github.com/calebjenkins/FakeAuth/blob/main/src/FakeAuth/Profiles/IFakeAuthProfile.cs),
+or you can inline your custom claims directly:
 
     services.UseFakeAuth((options) =>
     {
@@ -51,15 +50,22 @@ Or you can inline your custom claims directly:
 		options.Claims.Add(new Claim("Preffered_Location", "Disney Island"));
 	});
 
-See more of these examples in the [SampleWeb application](https://github.com/calebjenkins/FakeAuth/tree/main/Samples/FakeAuth.SampleWeb)
+See more of these examples in the [SampleWeb application](https://github.com/calebjenkins/FakeAuth/tree/main/Samples/FakeAuth.SampleWeb).
 
 ### Testing with FakeAuth
 
-You can easily set/override the default claims that the webserver uses via the `ConfigureFakeAuthClaims(...)` extension method on the `IServiceCollection` interface.
-For an example of this, see the [TestWebApplication class](https://github.com/calebjenkins/FakeAuth/blob/main/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs).
+FakeAuth works great with ASP.Net's testing framework. For some examples, take a look at the
+[FakeAuth.IntegrationTests project](https://github.com/calebjenkins/FakeAuth/blob/main/Tests/FakeAuth.IntegrationTests).
 
-In addition, the `HttpClient` class has an extension method called `SetFakeAuthClaims(...)` that allows you to set what specific claims FakeAuth will set for that specific
-`HttpClient` instance. For an example usage, see [this file](https://github.com/calebjenkins/FakeAuth/blob/main/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests.cs).
+In particular, you can set the FakeAuth claims for a specific `HttpClient` using `SetFakeAuthClaims(...)`:
+
+```csharp
+client.SetFakeAuthClaims(
+    new Claim(ClaimTypes.Name, "Joe Manager"),
+    new Claim(ClaimTypes.Role, "Manager")
+);
+```
+This lets you write tests that validate your authorization works as intended with and without the required claims.
 
 ### .NET 6
 
@@ -78,3 +84,7 @@ In .NET 6 you are no longer required to use a StartUp class. You can still use F
 - Do not use FakeAuth in a production enviroment
 - FakeAUth will only work on http://localhost/ - it's intededed to be a developent tool.
 - You will want to transition to an actual OAth / Claims provider before you go to Production, starting with Fake Auth, can help you establish and document which claims your application will rely on. 
+
+## Contributing to FakeAuth
+
+Please target any PRs to the `Develop` branch.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Or you can inline your custom claims directly:
 
 See more of these examples in the [SampleWeb application](https://github.com/calebjenkins/FakeAuth/tree/main/Samples/FakeAuth.SampleWeb)
 
+### Testing with FakeAuth
+
+You can easily set/override the default claims that the webserver uses via the `ConfigureFakeAuthClaims(...)` extension method on the `IServiceCollection` interface.
+For an example of this, see the [TestWebApplication class](https://github.com/calebjenkins/FakeAuth/blob/main/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs).
+
+In addition, the `HttpClient` class has an extension method called `SetFakeAuthClaims(...)` that allows you to set what specific claims FakeAuth will set for that specific
+`HttpClient` instance. For an example usage, see [this file](https://github.com/calebjenkins/FakeAuth/blob/main/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests.cs).
+
 ### .NET 6
 
 In .NET 6 you are no longer required to use a StartUp class. You can still use FakeAuth directly in the [Program class](https://github.com/calebjenkins/FakeAuth/blob/main/Samples/nuget.SampleWeb6.0/Program.cs):
@@ -70,6 +78,3 @@ In .NET 6 you are no longer required to use a StartUp class. You can still use F
 - Do not use FakeAuth in a production enviroment
 - FakeAUth will only work on http://localhost/ - it's intededed to be a developent tool.
 - You will want to transition to an actual OAth / Claims provider before you go to Production, starting with Fake Auth, can help you establish and document which claims your application will rely on. 
-
-
-

--- a/Tests/FakeAuth.IntegrationTests/Manager_AccessTests.cs
+++ b/Tests/FakeAuth.IntegrationTests/Manager_AccessTests.cs
@@ -22,25 +22,21 @@ namespace FakeAuth.IntegrationTests
 			//{
 			//	builder.ConfigureServices(services =>
 			//	{
-			//		services.UseFakeAuth((options) =>
-			//		{
-			//			options.Claims.Add(new Claim(ClaimTypes.Name, "Joe Manager"));
-			//			options.Claims.Add(new Claim(ClaimTypes.Role, "Manager"));
+			//		services.ConfigureFakeAuthClaims(
+			//			new Claim(ClaimTypes.Name, "Joe Manager"),
+			//			new Claim(ClaimTypes.Role, "Manager")
 			//		});
 			//	});
 			//});
-			// Set up - Sets Authorization to use the default FakeAuth Profile
-			Program.BuildAuth = new Action<WebApplicationBuilder>((builder) =>
-			{
-				// Needed for the protected endpoint (Role = Manager)
-				builder.Services.UseFakeAuth((options) =>
-				{
-					options.Claims.Add(new Claim(ClaimTypes.Name, "Joe Manager"));
-					options.Claims.Add(new Claim(ClaimTypes.Role, "Manager"));
-				});
-			});
 
-			_appUnderTest = new TestWebApplication();
+			_appUnderTest = new TestWebApplication
+			{
+				DefaultClaims =
+				{
+					new Claim(ClaimTypes.Name, "Joe Manager"),
+					new Claim(ClaimTypes.Role, "Manager"),
+				}
+			};
 		}
 
 

--- a/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests.cs
+++ b/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests.cs
@@ -22,7 +22,7 @@ namespace FakeAuth.IntegrationTests
 		[Fact]
 		public async Task Should_Be_Able_To_Access_NonManager_Endpoint()
 		{
-			var client = _appUnderTest.CreateClient();
+			using var client = _appUnderTest.CreateClient();
 
 			// Act
 			var response = await client.GetAsync("/api/open");
@@ -36,7 +36,7 @@ namespace FakeAuth.IntegrationTests
 		[Fact]
 		public async Task Should_Not_Be_Able_To_Access_Manager_Endpoint()
 		{
-			var client = _appUnderTest.CreateClient();
+			using var client = _appUnderTest.CreateClient();
 
 			// Act
 			var response = await client.GetAsync("/api/protected");
@@ -50,7 +50,7 @@ namespace FakeAuth.IntegrationTests
 		[Fact]
 		public async Task Should_Be_Able_To_Access_Manager_Endpoint_With_Http_Claims()
 		{
-			var client = _appUnderTest.CreateClient();
+			using var client = _appUnderTest.CreateClient();
 			client.SetFakeAuthClaims(new Claim(ClaimTypes.Role, "Manager"));
 
 			// Act

--- a/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests.cs
+++ b/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Builder;
 using System;
 using System.Threading.Tasks;
 using System.Net;
+using System.Security.Claims;
+using FakeAuth.Tests;
 
 namespace FakeAuth.IntegrationTests
 {
@@ -13,12 +15,6 @@ namespace FakeAuth.IntegrationTests
 		private readonly TestWebApplication _appUnderTest;
 		public Non_Manager_AccessTests()
 		{
-			// Set up - Sets Authorization to use the default FakeAuth Profile
-			Program.BuildAuth = new Action<WebApplicationBuilder>((builder) =>
-			{
-				builder.Services.UseFakeAuth();
-			});
-
 			_appUnderTest = new TestWebApplication();
 		}
 		public void Dispose() => _appUnderTest.Dispose();
@@ -49,6 +45,21 @@ namespace FakeAuth.IntegrationTests
 			response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 			var content = await response.Content.ReadAsStringAsync();
 			content.Should().BeEmpty();
+		}
+
+		[Fact]
+		public async Task Should_Be_Able_To_Access_Manager_Endpoint_With_Http_Claims()
+		{
+			var client = _appUnderTest.CreateClient();
+			client.SetFakeAuthClaims(new Claim(ClaimTypes.Role, "Manager"));
+
+			// Act
+			var response = await client.GetAsync("/api/protected");
+
+			// Assert
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			var content = await response.Content.ReadAsStringAsync();
+			content.Should().NotBeNullOrEmpty();
 		}
 	}
 }

--- a/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
+++ b/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
@@ -1,15 +1,23 @@
-﻿using Microsoft.AspNetCore.Mvc.Testing;
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Hosting;
 
 namespace FakeAuth.IntegrationTests
 {
 	public class TestWebApplication : WebApplicationFactory<Program>
 	{
+		public List<Claim> DefaultClaims { get; set; } = new ();
 		protected override IHost CreateHost(IHostBuilder builder)
 		{
+			builder.ConfigureServices(services =>
+			{
+				services.ConfigureFakeAuthClaims(DefaultClaims.ToArray());
+
+			});
 			// shared extra set up goes here
 			return base.CreateHost(builder);
-		} 
+		}
 
 		// Alternative approach, doesn't require a wrapper class:
 		//	var application = new WebApplicationFactory<Program>()

--- a/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
+++ b/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
@@ -7,26 +7,5 @@ namespace FakeAuth.IntegrationTests
 {
 	public class TestWebApplication : WebApplicationFactory<Program>
 	{
-		public List<Claim> DefaultClaims { get; set; } = new ();
-		protected override IHost CreateHost(IHostBuilder builder)
-		{
-			builder.ConfigureServices(services =>
-			{
-				services.ConfigureFakeAuthClaims(DefaultClaims.ToArray());
-
-			});
-			// shared extra set up goes here
-			return base.CreateHost(builder);
-		}
-
-		// Alternative approach, doesn't require a wrapper class:
-		//	var application = new WebApplicationFactory<Program>()
-		//	.WithWebHostBuilder(builder =>
-		//	{
-		//		builder.ConfigureServices(services =>
-		//		{
-		//			// Set up Services
-		//		});
-		//  });
 	}
 }

--- a/Tests/intigrationtests.SampleWeb/Program.cs
+++ b/Tests/intigrationtests.SampleWeb/Program.cs
@@ -8,8 +8,7 @@ using FakeAuth;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-BuildAuth(builder);
+ builder.Services.UseFakeAuth();
 
 builder.Services.AddAuthorization(options =>
 {
@@ -46,21 +45,7 @@ app.MapControllers();
 
 app.Run();
 
+// here to ensure visibility of Program class to tests
 public partial class Program
 {
-
-	// Added so we can override this in integration tests
-	// Also added to csproj file: <InternalsVisibleTo Include="FakeAuth.IntegrationTests" />
-	private static Action<WebApplicationBuilder> _buildAuth = (builder) =>
-			 {
-				 builder.Services.UseFakeAuth();
-			 //builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-			 // .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"));
-
-		 };
-	public static Action<WebApplicationBuilder> BuildAuth
-	{
-		get => _buildAuth;
-		set => _buildAuth = value;
-	}
 }

--- a/src/FakeAuth/AuthExtension.cs
+++ b/src/FakeAuth/AuthExtension.cs
@@ -2,6 +2,8 @@
 using FakeAuth.Profiles;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Linq;
+using System.Security.Claims;
 
 namespace FakeAuth
 {
@@ -24,6 +26,14 @@ namespace FakeAuth
 			.AddScheme<FakeAuthOptions, FakeAuthHandler>(FakeAuthConst.SchemaName, null);
 
 			services.Configure<FakeAuthOptions>(FakeAuthConst.SchemaName, options);
+		}
+
+		public static void ConfigureFakeAuthClaims(this IServiceCollection services, params Claim[] claims)
+		{
+			services.Configure<FakeAuthOptions>(FakeAuthConst.SchemaName, opts =>
+			{
+				opts.Claims = claims.ToList();
+			});
 		}
 	}
 }

--- a/src/FakeAuth/AuthExtension.cs
+++ b/src/FakeAuth/AuthExtension.cs
@@ -2,8 +2,6 @@
 using FakeAuth.Profiles;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Linq;
-using System.Security.Claims;
 
 namespace FakeAuth
 {
@@ -26,14 +24,6 @@ namespace FakeAuth
 			.AddScheme<FakeAuthOptions, FakeAuthHandler>(FakeAuthConst.SchemaName, null);
 
 			services.Configure<FakeAuthOptions>(FakeAuthConst.SchemaName, options);
-		}
-
-		public static void ConfigureFakeAuthClaims(this IServiceCollection services, params Claim[] claims)
-		{
-			services.Configure<FakeAuthOptions>(FakeAuthConst.SchemaName, opts =>
-			{
-				opts.Claims = claims.ToList();
-			});
 		}
 	}
 }

--- a/src/FakeAuth/Internal/FakeAuthConst.cs
+++ b/src/FakeAuth/Internal/FakeAuthConst.cs
@@ -9,5 +9,7 @@
 			public const string Name = "Fake User";
 			public const string Email = "fake@fakeuser.com";
 		}
+
+		public const string ClaimsHeaderName = "X-FakeAuth-Claims";
 	}
 }

--- a/src/FakeAuth/Tests/HttpClientExtensions.cs
+++ b/src/FakeAuth/Tests/HttpClientExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Security.Claims;
+using FakeAuth.Internal;
+
+namespace FakeAuth.Tests
+{
+	public static class HttpClientExtensions
+	{
+		public static void SetFakeAuthClaims(this HttpClient client, params Claim[] claims)
+		{
+			client.DefaultRequestHeaders.Remove(FakeAuthConst.ClaimsHeaderName);
+
+			using var stream = new MemoryStream();
+			using var writer = new BinaryWriter(stream);
+
+			foreach (var c in claims)
+			{
+				c.WriteTo(writer);
+			}
+
+			var headerValue = Convert.ToBase64String(stream.ToArray());
+
+			client.DefaultRequestHeaders.Add(FakeAuthConst.ClaimsHeaderName, headerValue);
+		}
+	}
+}


### PR DESCRIPTION
Two big changes here; first, this has a proof-of-concept to avoid having to mutate a static callback to control what the default claims are in the tests. Second, added a mechanism to serialize the desired claims into a header, then deserialize those claims in the handler so that you can test authz on a per-request basis.