### PR TITLE
Add configuration option to control what host is allowed to use FakeAuth

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -92,10 +92,10 @@ jobs:
 
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER} --include-symbols  --output .
-      if: ${{ steps.detect_develop.outcome == 'failure' }}
+      if: ${{ steps.detect_develop.outcome == 'success' }}
 
 
     - name: Push to Nuget
-      if: ${{ steps.detect_develop.outcome == 'failure' }}
+      if: ${{ steps.detect_develop.outcome == 'success' }}
       # run: dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}
       run: dotnet nuget push FakeAuth.${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -10,7 +10,6 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
-
     env:
       Nuget_Key: secrets.FAKEAUTH_NUGET_KEY
       Nuget_URL: "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -10,9 +10,10 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
-    env:
-      Nuget_Key: secrets.FAKEAUTH_NUGET_KEY
-      Nuget_URL: "https://api.nuget.org/v3/index.json"
+
+env:
+  Nuget_Key: secrets.FAKEAUTH_NUGET_KEY
+  Nuget_URL: "https://api.nuget.org/v3/index.json"
 
 jobs:
   build:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -92,10 +92,10 @@ jobs:
 
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER} --include-symbols  --output .
-      if: ${{ steps.detect_develop.outcome = 'failure' }}
+      if: ${{ steps.detect_develop.outcome == 'failure' }}
 
 
     - name: Push to Nuget
-      if: ${{ steps.detect_develop.outcome = 'failure' }}
+      if: ${{ steps.detect_develop.outcome == 'failure' }}
       # run: dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}
       run: dotnet nuget push FakeAuth.${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -78,8 +78,10 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-build
 
-    - name: Verify commit exists in origin/Develop
-      run: git branch --remote --contains | grep origin/Develop
+    - name: Verify is based on origin/Develop
+      # List commits that are ahead of origin/Develop through HEAD and look for the tip of the current branch. 
+      # If HEAD isn't ahead of origin/Develop, the git log bit will be empty and grep will fail
+      run: git log origin/Develop..HEAD | grep $(git rev-parse --short HEAD)
 
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER} --include-symbols  --output .

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -83,10 +83,19 @@ jobs:
       # If HEAD isn't ahead of origin/Develop, the git log bit will be empty and grep will fail
       run: git log origin/Develop..HEAD | grep $(git rev-parse --short HEAD)
 
+
+    - name: Detect if workflow is running on origin/Develop
+      id: detect_develop
+      run: git rev-parse HEAD | grep $(git rev-parse origin/Develop)
+      continue-on-error: true
+
+
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER} --include-symbols  --output .
+      if: success()
 
 
     - name: Push to Nuget
+      if: success()
       # run: dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}
       run: dotnet nuget push FakeAuth.${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -92,10 +92,10 @@ jobs:
 
     - name: Pack
       run: dotnet pack --configuration Release /p:Version=${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER} --include-symbols  --output .
-      if: success()
+      if: ${{ steps.detect_develop.outcome = 'failure' }}
 
 
     - name: Push to Nuget
-      if: success()
+      if: ${{ steps.detect_develop.outcome = 'failure' }}
       # run: dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}
       run: dotnet nuget push FakeAuth.${{steps.get_version.outputs.RELEASE_VERSION}}-ci-${BUILD_NUMBER}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.FAKEAUTH_NUGET_KEY}}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ client.SetFakeAuthClaims(
 );
 ```
 
-You can also re-use any profiles that impliment `IFakeAuthProfile` directly on your `HttpClient`:
+You can also re-use any profiles that implement `IFakeAuthProfile` directly on your `HttpClient`:
 ```csharp
  client.SetFakeAuthClaims<DefaultProfile>();
 ```
@@ -90,8 +90,8 @@ In .NET 6 you are no longer required to use a StartUp class. You can still use F
 - For Demo based applications that you want people to download and run - without needing to set up a production identity service first, or without sharing your application id/client secret information. 
 
 ### Not for - FakeAuth can not be used in production
-- Do not use FakeAuth in a production enviroment
-- FakeAuth will only work on http://localhost/ - it's intended to be a development tool.
+- Do not use FakeAuth in a production environment
+- FakeAuth will only work on http://localhost/ by default - it's intended to be a development tool.
 - You will want to transition to an actual OAuth / Claims provider before you go to Production. Starting with Fake Auth can help you establish and document which claims your application will rely on. 
 
 ## Contributing to FakeAuth

--- a/Tests/FakeAuth.IntegrationTests/Manager_AccessTests.cs
+++ b/Tests/FakeAuth.IntegrationTests/Manager_AccessTests.cs
@@ -52,6 +52,21 @@ namespace FakeAuth.IntegrationTests
 			content.Should().NotBeNullOrEmpty();
 		}
 
+		[Fact]
+		public async Task Should_Be_Able_To_Access_Manager_Endpoint_Byhand_claims()
+		{
+			_client.DefaultRequestHeaders.Remove(FakeAuthDefaults.ClaimsHeaderName);
+			_client.DefaultRequestHeaders.Add(FakeAuthDefaults.ClaimsHeaderName, $"{ClaimTypes.Name},Joe Manager");
+			_client.DefaultRequestHeaders.Add(FakeAuthDefaults.ClaimsHeaderName, $"{ClaimTypes.Role},Manager");
+			// Act
+			var response = await _client.GetAsync("/api/protected");
+
+			// Assert
+			response.StatusCode.Should().Be(HttpStatusCode.OK);
+			var content = await response.Content.ReadAsStringAsync();
+			content.Should().NotBeNullOrEmpty();
+		}
+
 		public void Dispose()
 		{
 			_client?.Dispose();

--- a/Tests/FakeAuth.IntegrationTests/Manager_AccessTests_with_Profiles.cs
+++ b/Tests/FakeAuth.IntegrationTests/Manager_AccessTests_with_Profiles.cs
@@ -20,7 +20,7 @@ public class Manager_AccessTests_with_Profiles : IDisposable
 		_appUnderTest = new TestWebApplication();
 		_client = _appUnderTest.CreateClient();
 
-		_client.SetFakeAuthClaimns<ManagerJoeProfile>();
+		_client.SetFakeAuthClaims<ManagerJoeProfile>();
 	}
 
 

--- a/Tests/FakeAuth.IntegrationTests/NonLocalhostRejectionTests.cs
+++ b/Tests/FakeAuth.IntegrationTests/NonLocalhostRejectionTests.cs
@@ -8,32 +8,38 @@ namespace FakeAuth.IntegrationTests;
 [Collection("Integration Tests")]
 public sealed class NonLocalhostTests
 {
-	[Fact]
-	public async Task ThrowsOnNonLocalhost()
+	[Theory]
+	[InlineData("localhost", HttpStatusCode.OK)]
+	[InlineData("example.com", HttpStatusCode.Unauthorized)]
+	public async Task ThrowsOnNonLocalhostByDefault(string host, HttpStatusCode expected)
 	{
 		using var app = new TestWebApplication
 		{
-			Host = "example.com",
+			Host = host,
 		};
 		using var client = app.CreateClient();
 
 		var result = await client.GetAsync("/api/open");
 
-		result.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+		result.StatusCode.Should().Be(expected);
 	}
 
-	[Fact]
-	public async Task AllowsNonLocalhostWhenConfigured()
+	[Theory]
+	[InlineData("example.com", HttpStatusCode.OK)]
+	[InlineData("foobar.com", HttpStatusCode.OK)]
+	[InlineData("localhost", HttpStatusCode.OK)]
+	[InlineData("google.com", HttpStatusCode.Unauthorized)]
+	public async Task AllowsNonLocalhostWhenConfigured(string host, HttpStatusCode expected)
 	{
 		using var app = new TestWebApplication
 		{
-			Host = "example.com",
-			AllowedHost = "example.com",
+			Host = host,
+			AllowedHosts = new[] { "example.com", "foobar.com", "localhost" },
 		};
 		using var client = app.CreateClient();
 
 		var result = await client.GetAsync("/api/open");
 
-		result.StatusCode.Should().Be(HttpStatusCode.OK);
+		result.StatusCode.Should().Be(expected);
 	}
 }

--- a/Tests/FakeAuth.IntegrationTests/NonLocalhostRejectionTests.cs
+++ b/Tests/FakeAuth.IntegrationTests/NonLocalhostRejectionTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace FakeAuth.IntegrationTests;
+
+[Collection("Integration Tests")]
+public sealed class NonLocalhostTests
+{
+	[Fact]
+	public async Task ThrowsOnNonLocalhost()
+	{
+		using var app = new TestWebApplication
+		{
+			Host = "example.com",
+		};
+		using var client = app.CreateClient();
+
+		var result = await client.GetAsync("/api/open");
+
+		result.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task AllowsNonLocalhostWhenConfigured()
+	{
+		using var app = new TestWebApplication
+		{
+			Host = "example.com",
+			AllowedHost = "example.com",
+		};
+		using var client = app.CreateClient();
+
+		var result = await client.GetAsync("/api/open");
+
+		result.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+}

--- a/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests_with_Profile.cs
+++ b/Tests/FakeAuth.IntegrationTests/Non_Manager_AccessTests_with_Profile.cs
@@ -21,7 +21,7 @@ namespace FakeAuth.IntegrationTests
 			_appUnderTest = new TestWebApplication();
 			_client = _appUnderTest.CreateClient();
 
-			_client.SetFakeAuthClaimns<NonManagerJoeProfile>();
+			_client.SetFakeAuthClaims<NonManagerJoeProfile>();
 		}
 		
 		public void Dispose()

--- a/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
+++ b/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
@@ -1,4 +1,7 @@
-﻿using intigrationtests.SampleWeb;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using intigrationtests.SampleWeb;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,7 +11,7 @@ namespace FakeAuth.IntegrationTests
 	public class TestWebApplication : WebApplicationFactory<Program>
 	{
 		public string? Host { get; set; }
-		public string? AllowedHost { get; set; }
+		public IEnumerable<string> AllowedHosts { get; set; } = ImmutableArray<string>.Empty;
 
 		protected override void ConfigureWebHost(IWebHostBuilder builder)
 		{
@@ -22,7 +25,7 @@ namespace FakeAuth.IntegrationTests
 				});
 				services.Configure<FakeAuthOptions>(FakeAuthDefaults.SchemaName, opts =>
 				{
-					opts.AllowedHost = AllowedHost ?? FakeAuthOptions.DefaultAllowedHost;
+					opts.AllowedHosts = AllowedHosts.Any() ? AllowedHosts : new[] { FakeAuthOptions.DefaultAllowedHost };
 				});
 			});
 		}

--- a/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
+++ b/Tests/FakeAuth.IntegrationTests/TestWebApplication.cs
@@ -1,11 +1,30 @@
-﻿using System.Collections.Generic;
-using System.Security.Claims;
+﻿using intigrationtests.SampleWeb;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace FakeAuth.IntegrationTests
 {
 	public class TestWebApplication : WebApplicationFactory<Program>
 	{
+		public string? Host { get; set; }
+		public string? AllowedHost { get; set; }
+
+		protected override void ConfigureWebHost(IWebHostBuilder builder)
+		{
+			base.ConfigureWebHost(builder);
+
+			builder.ConfigureServices(services =>
+			{
+				services.Configure<HostRewriteSettings>(s =>
+				{
+					s.Host = Host;
+				});
+				services.Configure<FakeAuthOptions>(FakeAuthDefaults.SchemaName, opts =>
+				{
+					opts.AllowedHost = AllowedHost ?? FakeAuthOptions.DefaultAllowedHost;
+				});
+			});
+		}
 	}
 }

--- a/Tests/intigrationtests.SampleWeb/HostRewriteSettings.cs
+++ b/Tests/intigrationtests.SampleWeb/HostRewriteSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace intigrationtests.SampleWeb;
+
+public sealed class HostRewriteSettings
+{
+	public string Host { get; set; }
+}

--- a/Tests/intigrationtests.SampleWeb/Program.cs
+++ b/Tests/intigrationtests.SampleWeb/Program.cs
@@ -1,15 +1,14 @@
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc.Authorization;
-using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
 using FakeAuth;
+using intigrationtests.SampleWeb;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddAuthentication()
 	.AddFakeAuth();
+builder.Services.Configure<HostRewriteSettings>(_ => { });
 
 builder.Services.AddAuthorization(options =>
 {
@@ -19,9 +18,6 @@ builder.Services.AddAuthorization(options =>
 builder.Services.AddRazorPages()
 	 .AddMicrosoftIdentityUI();
 builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-
-//For(typeof(ILogger<>)).Use(typeof(Logger<>));
-
 
 var app = builder.Build();
 
@@ -37,6 +33,17 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.Use((ctx, next) =>
+{
+	var settings = app.Services.GetRequiredService<IOptions<HostRewriteSettings>>();
+
+	if (!string.IsNullOrEmpty(settings.Value.Host))
+	{
+		ctx.Request.Host = new HostString(settings.Value.Host);
+	}
+	return next();
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/FakeAuth/FakeAuth.csproj
+++ b/src/FakeAuth/FakeAuth.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>FakeAuth</RootNamespace>
     <AssemblyName>FakeAuth</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Caleb Jenkins</Authors>
     <Company>Caleb Jenkins</Company>

--- a/src/FakeAuth/FakeAuthHandler.cs
+++ b/src/FakeAuth/FakeAuthHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -30,10 +31,11 @@ namespace FakeAuth
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 		{
 			var host = Context.Request.Host.Host;
-			if (host.ToUpper() != Options.AllowedHost.ToUpper())
+			if (!Options.AllowedHosts.Any(x => host.Equals(x, StringComparison.OrdinalIgnoreCase)))
 			{
-				_logger.LogError("Failing authentication due to unexpected host {Host} when allowed host is {AllowedHost}", host, Options.AllowedHost);
-				return AuthenticateResult.Fail($"FakeAuth fails all requests that do not match {Options.AllowedHost}; got host {host}.");
+				var hostsString = string.Join(", ", Options.AllowedHosts);
+				_logger.LogError("Failing authentication due to unexpected host {Host} when allowed hosts is {AllowedHost}", host, hostsString);
+				return AuthenticateResult.Fail($"FakeAuth fails all requests that do not match {hostsString}; got host {host}.");
 			}
 
 			var claims = Options.Claims;

--- a/src/FakeAuth/FakeAuthHandler.cs
+++ b/src/FakeAuth/FakeAuthHandler.cs
@@ -29,23 +29,23 @@ namespace FakeAuth
 		protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 		{
-			if (!CurrentUri.ToUpper().Contains("://LOCALHOST"))
+			var host = Context.Request.Host.Host;
+			if (host.ToUpper() != Options.AllowedHost.ToUpper())
 			{
-				_logger.LogError("Library only intended for localhost developement");
-				return AuthenticateResult.Fail("FakeAuth can only be used for localhost developement. Please impliment another OAuth solution for other scenarios");
+				_logger.LogError("Failing authentication due to unexpected host {Host} when allowed host is {AllowedHost}", host, Options.AllowedHost);
+				return AuthenticateResult.Fail($"FakeAuth fails all requests that do not match {Options.AllowedHost}; got host {host}.");
 			}
 
 			var claims = Options.Claims;
 			if (Request.Headers.ContainsKey(FakeAuthDefaults.ClaimsHeaderName))
 			{
-				var headerVal = Request.Headers[FakeAuthDefaults.ClaimsHeaderName][0];
-				using var stream = new MemoryStream(Convert.FromBase64String(headerVal));
-				using var reader = new BinaryReader(stream);
+				var claimValues = Request.Headers[FakeAuthDefaults.ClaimsHeaderName];
 
 				claims = new List<Claim>();
-				while (stream.Position < stream.Length)
+				foreach(var c in claimValues)
 				{
-					claims.Add(new Claim(reader));
+					var parts = c.Split(",");
+					claims.Add(new Claim(parts[0], parts[1]));
 				}
 			}
 

--- a/src/FakeAuth/FakeAuthOptions.cs
+++ b/src/FakeAuth/FakeAuthOptions.cs
@@ -14,6 +14,6 @@ namespace FakeAuth
 
 		public List<Claim> Claims { get; set; }
 
-		public string AllowedHost { get; set; } = DefaultAllowedHost;
+		public IEnumerable<string> AllowedHosts { get; set; } = new[] { DefaultAllowedHost };
 	}
 }

--- a/src/FakeAuth/FakeAuthOptions.cs
+++ b/src/FakeAuth/FakeAuthOptions.cs
@@ -6,11 +6,14 @@ namespace FakeAuth
 {
 	public class FakeAuthOptions : AuthenticationSchemeOptions
 	{
+		public const string DefaultAllowedHost = "localhost";
 		public FakeAuthOptions()
 		{
 			Claims = new List<Claim>();
 		}
 
 		public List<Claim> Claims { get; set; }
+
+		public string AllowedHost { get; set; } = DefaultAllowedHost;
 	}
 }

--- a/src/FakeAuth/Testing/HttpClientExtensions.cs
+++ b/src/FakeAuth/Testing/HttpClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using FakeAuth.Profiles;
 using System;
+using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -9,7 +10,7 @@ namespace FakeAuth.Testing
 {
 	public static class HttpClientExtensions
 	{
-		public static void SetFakeAuthClaimns<TProfile>(this HttpClient client) where TProfile : IFakeAuthProfile, new()
+		public static void SetFakeAuthClaims<TProfile>(this HttpClient client) where TProfile : IFakeAuthProfile, new()
 		{
 			TProfile profile = new TProfile();
 			var claims = profile.GetClaims().ToArray();
@@ -20,17 +21,10 @@ namespace FakeAuth.Testing
 		{
 			client.DefaultRequestHeaders.Remove(FakeAuthDefaults.ClaimsHeaderName);
 
-			using var stream = new MemoryStream();
-			using var writer = new BinaryWriter(stream);
-
 			foreach (var c in claims)
 			{
-				c.WriteTo(writer);
+				client.DefaultRequestHeaders.Add(FakeAuthDefaults.ClaimsHeaderName, $"{c.Type},{c.Value}");
 			}
-
-			var headerValue = Convert.ToBase64String(stream.ToArray());
-
-			client.DefaultRequestHeaders.Add(FakeAuthDefaults.ClaimsHeaderName, headerValue);
 		}
 	}
 }


### PR DESCRIPTION
# Use case

Building end-to-end testing such that writing e2e tests via Cypress (e.g.) I wouldn't have to instrument logging in via Azure AD, plus I wouldn't have to administer a testing-only AD account (e.g.) in order to validate that my app works correctly when logged in as a certain kind of user. The intent is to control it similar to this so that FakeAuth is only in play when it's needed:

```csharp
var authBuilder = app.AddAuthentication();
var fakeAuthHost = Configuration["FakeAuthHost"];
if(!string.IsNullOrEmpty(fakeAuthHost)
{
    authBuilder.AddFakeAuth(opts => {
        opts.AllowedHost = fakeAuthHost;
    });
}
```
I'll likely use something like `backend` for the `FakeAuthHost` setting to match what I've configured in, say, a `docker-compose.yml` file.

I changed the claims serialization as well so that we can set the claims in a textual way instead of the binary serialization scheme that it was using.

(Fixes #13)